### PR TITLE
Create paper type header

### DIFF
--- a/src/paper_type.h
+++ b/src/paper_type.h
@@ -1,3 +1,5 @@
+#pragma once
+
 enum paper_type {
     A0,
     A1,

--- a/src/paper_type.h
+++ b/src/paper_type.h
@@ -1,0 +1,15 @@
+enum paper_type {
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+    POSTER,
+    STICKER70,
+    STICKER49,
+    BADGE,
+    OTHER
+};


### PR DESCRIPTION
## Summary
There is an enum which contains values for each paper style mentioned [in the old repo](https://github.com/SCH-KB-PR/kbpr-ps/blob/main/src/presets.jsx), so it should cover most use cases. 

Also since this is the first PR, it inherently carries with it a naming convention, in this case `snake_case`, but if we'd prefer a different naming convention, I'm open to changing the name of the enum.

## Potential upsides
Since enum values can be given `int` values aswell, I thought about maybe using these as indexes for arrays, could potentially look something like this:
```cpp
class Paper {
// ...
  static constexpr int sizes[9] = {74, 105, 148, 210, 297, 420, 594, 841, 1189};
// ...
  int width = sizes[paper_type];
  int height = sizes[paper_type +1];
}
```
This would of course only work for A-Series type papers, and it might not be that elegant, but I thought I'd share it anyway.

## Potential downsides
Paper types might be better as a class, since then we could abstract all the standard A-Series paper types to another class, which would inherit from the basic basic `paper_type` class, but since I don't think A8, A9, etc... would ever be needed for our use case, it might just be useless abstraction.
