### PR TITLE
build fix on debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ output/
 *.fdb_latexmk
 *.fls
 thesis.pdf
+
+# JetBrains
+.idea/

--- a/src/util/pnghelper.cpp
+++ b/src/util/pnghelper.cpp
@@ -77,7 +77,7 @@ void PNGHelper::save_png(const std::string& path, const QImage& image, double dp
 void PNGHelper::add_exif_data(const std::string& path, const DocumentPreset& properties) {
     auto image = Exiv2::ImageFactory::open(path);
 
-    if (!image) {
+    if (!image.get()) {
         throw std::runtime_error("Failed to open image file.");
     }
 


### PR DESCRIPTION
Original build output from ninja:

```
FAILED: printf.p/src_util_pnghelper.cpp.o 
c++ -Iprintf.p -I. -I.. -I../src -I../src/interfaces -I../src/img -I../src/img/filters -I../src/img/tiling -I../src/settings -I../src/util -I../src/ui -I../src/qml -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtCore -I/home/zsotroav/Qt/6.10.0/gcc_64/include -I/home/zsotroav/Qt/6.10.0/gcc_64/mkspecs/linux-g++ -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtWidgets -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtGui -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQml -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQmlIntegration -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtNetwork -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQuick -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQmlMeta -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQmlModels -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtQmlWorkerScript -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtOpenGL -I/home/zsotroav/Qt/6.10.0/gcc_64/include/QtLabsPlatform -I/usr/include/poppler/qt6 -I/usr/include/poppler -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++23 -O0 -g -DQT_LABSPLATFORM_LIB -DQT_QUICK_LIB -DQT_QMLMETA_LIB -DQT_QMLWORKERSCRIPT_LIB -DQT_QMLMODELS_LIB -DQT_OPENGL_LIB -DQT_QML_LIB -DQT_QMLINTEGRATION_LIB -DQT_NETWORK_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -fPIC -isystem/usr/include/opencv4 -MD -MQ printf.p/src_util_pnghelper.cpp.o -MF printf.p/src_util_pnghelper.cpp.o.d -o printf.p/src_util_pnghelper.cpp.o -c ../src/util/pnghelper.cpp
../src/util/pnghelper.cpp: In static member function ‘static void PNGHelper::add_exif_data(const std::string&, const DocumentPreset&)’:
../src/util/pnghelper.cpp:80:9: error: no match for ‘operator!’ (operand type is ‘std::auto_ptr<Exiv2::Image>’)
   80 |     if (!image) {
      |         ^~~~~~
../src/util/pnghelper.cpp:80:9: note: candidate: ‘operator!(bool)’ (built-in)
../src/util/pnghelper.cpp:80:9: note:   no known conversion for argument 1 from ‘std::auto_ptr<Exiv2::Image>’ to ‘bool’
ninja: build stopped: 
```

This can seemingly be fixed with

```diff
-    if (!image) {
+    if (!image.get()) {
```

Unsure if this breaks stuff somewhere else, but works on my machine™

Linux mint 22.1