### PR TITLE
Switch to raw pointers for tiling algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ output/
 
 # vscode
 .vscode/settings.json
+*.code-workspace
 
 # latex
 *.aux

--- a/src/img/cached_image.hpp
+++ b/src/img/cached_image.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <opencv2/opencv.hpp>
+
 #include "icachable.hpp"
 #include "icache.hpp"
 
@@ -10,14 +11,13 @@ class CachedImage : ICache {
     cv::Mat cache;
     bool isDirty;
 
-    
-    public:
+  public:
     CachedImage(const ICachableImage& source);
-    
+
     void regenerate();
-    
+
     cv::Mat get_img();
-    
+
     int get_width();
 
     int get_height();

--- a/src/img/filters/ifilter.hpp
+++ b/src/img/filters/ifilter.hpp
@@ -3,5 +3,5 @@
 
 class IFilter {
   public:
-    virtual cv::Mat apply(const cv::Mat &image) const = 0;
+    virtual cv::Mat apply(const cv::Mat& image) const = 0;
 };

--- a/src/img/filters/mask.cpp
+++ b/src/img/filters/mask.cpp
@@ -2,9 +2,9 @@
 
 #include "size.hpp"
 
-MaskFilter::MaskFilter(const cv::Mat &mask) : mask(mask) {}
+MaskFilter::MaskFilter(const cv::Mat& mask) : mask(mask) {}
 
-cv::Mat MaskFilter::apply(const cv::Mat &image) const {
+cv::Mat MaskFilter::apply(const cv::Mat& image) const {
     // convert mask
     auto fitMask = SizeFilter::resize(mask, image.cols, image.rows);
     if (invert) {
@@ -14,7 +14,7 @@ cv::Mat MaskFilter::apply(const cv::Mat &image) const {
 
     // background
     cv::Mat white(image.size(), CV_32FC3, cv::Scalar(1.0, 1.0, 1.0));
-    
+
     // convert image
     cv::Mat imagef;
     image.convertTo(imagef, CV_32FC3, 1.0 / 255.0);
@@ -24,7 +24,7 @@ cv::Mat MaskFilter::apply(const cv::Mat &image) const {
     cv::multiply(cv::Scalar(1.0, 1.0, 1.0) - fitMask, white, white);
     cv::add(imagef, white, blended);
     blended.convertTo(blended, CV_8UC3, 255.0);
-    
+
     return blended;
 }
 

--- a/src/img/filters/mask.hpp
+++ b/src/img/filters/mask.hpp
@@ -9,9 +9,9 @@ class MaskFilter : public IFilter {
     bool invert = false;
 
   public:
-    MaskFilter(const cv::Mat &mask);
+    MaskFilter(const cv::Mat& mask);
 
-    cv::Mat apply(const cv::Mat &image) const override;
+    cv::Mat apply(const cv::Mat& image) const override;
 
     void setInvert(bool invert);
 };

--- a/src/img/filters/padding.cpp
+++ b/src/img/filters/padding.cpp
@@ -3,7 +3,7 @@
 PaddingFilter::PaddingFilter(int padding, bool guide, int bleed, int line_thickness, cv::Scalar line_color)
     : padding(padding), guide(guide), bleed(bleed), line_thickness(line_thickness), line_color(line_color) {}
 
-cv::Mat PaddingFilter::apply(const cv::Mat &image) const {
+cv::Mat PaddingFilter::apply(const cv::Mat& image) const {
     cv::Mat padded;
     auto expand = std::max(padding, (guide ? line_thickness : 0));
 
@@ -25,6 +25,7 @@ cv::Mat PaddingFilter::apply(const cv::Mat &image) const {
         }
 
         auto lfx = (line_thickness + 1) / 2;
+        // clang-format off
         // the lines are only outside of the image, show only on the gutter
         // top
         cv::line(padded, cv::Point(0, expand - lfx), cv::Point(blep - lfx, expand - lfx), line_color, line_thickness, cv::LINE_8);
@@ -41,6 +42,7 @@ cv::Mat PaddingFilter::apply(const cv::Mat &image) const {
         // right
         cv::line(padded, cv::Point(width - 1 - expand + lfx, 0), cv::Point(width - 1 - expand + lfx, blep - lfx), line_color, line_thickness, cv::LINE_8);
         cv::line(padded, cv::Point(width - 1 - expand + lfx, height - 1 - blep + lfx), cv::Point(width - 1 - expand + lfx, height - 1), line_color, line_thickness, cv::LINE_8);
+        // clang-format on
     }
 
     return padded;

--- a/src/img/filters/padding.hpp
+++ b/src/img/filters/padding.hpp
@@ -7,15 +7,15 @@ class PaddingFilter : public IFilter {
   private:
     int padding;
     bool guide;
-    int bleed; // -1 for full lines
+    int bleed;  // -1 for full lines
     int line_thickness;
     cv::Scalar line_color;
     cv::Scalar bg_color = cv::Scalar(255, 255, 255);
 
   public:
     // TODO config
-    PaddingFilter(int padding, bool guide = false, int bleed = 0,
-                  int line_thickness = 1, cv::Scalar line_color = cv::Scalar(0, 0, 0));
+    PaddingFilter(int padding, bool guide = false, int bleed = 0, int line_thickness = 1,
+                  cv::Scalar line_color = cv::Scalar(0, 0, 0));
 
-    cv::Mat apply(const cv::Mat &image) const override;
+    cv::Mat apply(const cv::Mat& image) const override;
 };

--- a/src/img/filters/rotate.cpp
+++ b/src/img/filters/rotate.cpp
@@ -6,11 +6,9 @@ bool RotateFilter::get_rotated() const { return rotated; }
 
 void RotateFilter::set_rotated(bool rotated) { this->rotated = rotated; }
 
-cv::Mat RotateFilter::apply(const cv::Mat& image) const {
-    return rotated ? RotateFilter::rotate(image, rotation_dir) : image;
-}
+cv::Mat RotateFilter::apply(const cv::Mat& image) const { return rotated ? RotateFilter::rotate(image, rotation_dir) : image; }
 
-cv::Mat RotateFilter::rotate(const cv::Mat &image, cv::RotateFlags rotation_dir) {
+cv::Mat RotateFilter::rotate(const cv::Mat& image, cv::RotateFlags rotation_dir) {
     cv::Mat rotated;
     cv::rotate(image, rotated, rotation_dir);
     return rotated;

--- a/src/img/filters/rotate.hpp
+++ b/src/img/filters/rotate.hpp
@@ -13,6 +13,6 @@ class RotateFilter : public IFilter {
     bool get_rotated() const;
     void set_rotated(bool rotated);
 
-    cv::Mat apply(const cv::Mat &image) const override;
-    static cv::Mat rotate(const cv::Mat &image, cv::RotateFlags rotation_dir);
+    cv::Mat apply(const cv::Mat& image) const override;
+    static cv::Mat rotate(const cv::Mat& image, cv::RotateFlags rotation_dir);
 };

--- a/src/img/filters/size.cpp
+++ b/src/img/filters/size.cpp
@@ -7,9 +7,9 @@ void SizeFilter::set_size(int width, int height) {
     this->height = height;
 }
 
-cv::Mat SizeFilter::apply(const cv::Mat &image) const { return SizeFilter::resize(image, width, height); }
+cv::Mat SizeFilter::apply(const cv::Mat& image) const { return SizeFilter::resize(image, width, height); }
 
-cv::Mat SizeFilter::resize(const cv::Mat &image, int width, int height, int interDown, int interUp) {
+cv::Mat SizeFilter::resize(const cv::Mat& image, int width, int height, int interDown, int interUp) {
     if (width == image.cols && height == image.rows) {
         return image;
     }
@@ -25,6 +25,6 @@ cv::Mat SizeFilter::resize(const cv::Mat &image, int width, int height, int inte
     return resized;
 }
 
-cv::Mat SizeFilter::resize_to_width(const cv::Mat &image, int width, int interDown, int interUp) {
+cv::Mat SizeFilter::resize_to_width(const cv::Mat& image, int width, int interDown, int interUp) {
     return SizeFilter::resize(image, width, image.rows * width / image.cols, interDown, interUp);
 }

--- a/src/img/filters/size.hpp
+++ b/src/img/filters/size.hpp
@@ -16,10 +16,10 @@ class SizeFilter : public IFilter {
 
     void set_size(int width, int height);
 
-    cv::Mat apply(const cv::Mat &image) const override;
+    cv::Mat apply(const cv::Mat& image) const override;
 
-    static cv::Mat resize(const cv::Mat &image, int width, int height, int interDown = sizeInterDown,
+    static cv::Mat resize(const cv::Mat& image, int width, int height, int interDown = sizeInterDown,
                           int interUp = sizeInterUp);
 
-    static cv::Mat resize_to_width(const cv::Mat &image, int width, int interDown = sizeInterDown, int interUp = sizeInterUp);
+    static cv::Mat resize_to_width(const cv::Mat& image, int width, int interDown = sizeInterDown, int interUp = sizeInterUp);
 };

--- a/src/img/image_source.cpp
+++ b/src/img/image_source.cpp
@@ -1,6 +1,7 @@
 #include "image_source.hpp"
 
 #include <stdexcept>
+
 #include "rotate.hpp"
 
 ImageSource::ImageSource(cv::Mat source, int amount, double width_mm, double height_mm)
@@ -58,8 +59,8 @@ void ImageSource::set_size_px(int width, int height, bool auto_rotate) {
     cached.set_dirty();
 }
 
-void ImageSource::set_rotated(bool rotated) { 
+void ImageSource::set_rotated(bool rotated) {
     if (rotate_filter.get_rotated() == rotated) return;
-    rotate_filter.set_rotated(rotated); 
-    cached.set_dirty(); 
+    rotate_filter.set_rotated(rotated);
+    cached.set_dirty();
 }

--- a/src/img/image_source.hpp
+++ b/src/img/image_source.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
+#include <memory>
 #include <opencv2/opencv.hpp>
 #include <vector>
-#include <memory>
 
 #include "cached_image.hpp"
-#include "ifilter.hpp"
 #include "icachable.hpp"
-#include "size.hpp"
+#include "ifilter.hpp"
 #include "rotate.hpp"
+#include "size.hpp"
 
 class ImageSource : ICachableImage {
   private:

--- a/src/img/tiling/grid_tiling.cpp
+++ b/src/img/tiling/grid_tiling.cpp
@@ -1,10 +1,6 @@
 #include "grid_tiling.hpp"
 
-#include <numeric>
-
 #include "padding.hpp"
-#include "rotate.hpp"
-#include "size.hpp"
 #include "tile.hpp"
 #include "convert.hpp"
 
@@ -20,7 +16,7 @@ int GridTiling::calc_waste(int document_width, int tile_width, int tile_height, 
     return (document_width - tile_width * columns) * tile_height * rows;
 }
 
-cv::Mat GridTiling::generate(const DocumentPreset& preset, std::vector<std::shared_ptr<ImageSource>> images) {
+cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) {
     if (images.empty()) throw std::invalid_argument("No images provided");
 
     auto padding = preset.get_padding_px();
@@ -29,7 +25,7 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, std::vector<std::shar
     auto uniform_height_px = convert::mm_to_pixel(images[0]->height_mm, ppi);
 
     // set uniform sizes and padding
-    for (auto img : images) {
+    for (const auto& img : images) {
         img->set_size_px(uniform_width_px, uniform_height_px, true);
         img->add_filter(std::make_shared<PaddingFilter>(padding, preset.get_guide(), preset.get_bleed_px(), preset.get_line_width()));
         img->burn();
@@ -49,14 +45,16 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, std::vector<std::shar
 
     
     // instantiate tiles based on amounts
-    std::vector<Tile> tiles = {};
-    for (auto img : images) {
+    std::vector<Tile> tiles;
+    // Assuming that on average, each image is printed three times.
+    tiles.reserve(images.size() * 3);
+
+    for (const auto& img : images) {
         for (int i = 0; i < img->get_amount(); i++) {
             tiles.push_back(Tile(img));
         }
     }
     
-
     int quantity = static_cast<int>(tiles.size());
     int document_height = 0;
     std::cout << "\n\n";

--- a/src/img/tiling/grid_tiling.cpp
+++ b/src/img/tiling/grid_tiling.cpp
@@ -1,8 +1,8 @@
 #include "grid_tiling.hpp"
 
+#include "convert.hpp"
 #include "padding.hpp"
 #include "tile.hpp"
-#include "convert.hpp"
 
 int GridTiling::calc_waste(int document_width, int tile_width, int tile_height, int amount) {
     int columns = std::floor(static_cast<double>(document_width) / tile_width);
@@ -27,7 +27,8 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<Ima
     // set uniform sizes and padding
     for (const auto& img : images) {
         img->set_size_px(uniform_width_px, uniform_height_px, true);
-        img->add_filter(std::make_shared<PaddingFilter>(padding, preset.get_guide(), preset.get_bleed_px(), preset.get_line_width()));
+        img->add_filter(
+            std::make_shared<PaddingFilter>(padding, preset.get_guide(), preset.get_bleed_px(), preset.get_line_width()));
         img->burn();
     }
 
@@ -43,7 +44,6 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<Ima
         throw std::invalid_argument("Invalid image size");
     }
 
-    
     // instantiate tiles based on amounts
     std::vector<Tile> tiles;
     // Assuming that on average, each image is printed three times.
@@ -54,7 +54,7 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<Ima
             tiles.push_back(Tile(img));
         }
     }
-    
+
     int quantity = static_cast<int>(tiles.size());
     int document_height = 0;
     std::cout << "\n\n";
@@ -88,7 +88,7 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<Ima
             }
             quantity += extra;
         }
-        
+
         columns = std::min(columns, quantity - i);
 
         for (int j = 0; j < columns; j++) {
@@ -103,7 +103,7 @@ cv::Mat GridTiling::generate(const DocumentPreset& preset, const std::vector<Ima
         document_height += rotate_row ? tile_width : tile_height;
         i += columns;
     }
-    
+
     cv::Mat document = cv::Mat::ones(document_height, document_width, CV_8UC3);
     document.setTo(cv::Scalar(255, 255, 255));
 

--- a/src/img/tiling/grid_tiling.hpp
+++ b/src/img/tiling/grid_tiling.hpp
@@ -6,5 +6,5 @@ class GridTiling : public Tiling {
     int calc_waste(int document_width, int tile_width, int tile_height, int amount);
 
   public:
-    cv::Mat generate(const DocumentPreset& preset, std::vector<std::shared_ptr<ImageSource>> images) override;
+    cv::Mat generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) override;
 };

--- a/src/img/tiling/strip_tiling.cpp
+++ b/src/img/tiling/strip_tiling.cpp
@@ -2,49 +2,52 @@
 
 #include "padding.hpp"
 
-std::vector<std::shared_ptr<Tile>>& StripTiling::ph_sort(std::vector<std::shared_ptr<Tile>>& tiles,
-                                                         PriorityHeuristic heuristic) {
+std::vector<Tile>& StripTiling::ph_sort(std::vector<Tile>& tiles, PriorityHeuristic heuristic) {
     // make every tile portrait
     for (auto tile : tiles) {
-        if (tile->get_width() > tile->get_height()) {
-            tile->rotate();
+        if (tile.get_width() > tile.get_height()) {
+            tile.rotate();
         }
     }
 
-    switch (heuristic) {
-        case PriorityHeuristic::WIDTH:
-            std::sort(tiles.begin(), tiles.end(), [](const std::shared_ptr<Tile>& a, const std::shared_ptr<Tile>& b) {
-                return a->get_width() > b->get_width();
-            });
-            break;
-        case PriorityHeuristic::HEIGHT:
-            std::sort(tiles.begin(), tiles.end(), [](const std::shared_ptr<Tile>& a, const std::shared_ptr<Tile>& b) {
-                return a->get_height() > b->get_height();
-            });
-            break;
-        case PriorityHeuristic::DIAGONAL:
-            std::sort(tiles.begin(), tiles.end(), [](const std::shared_ptr<Tile>& a, const std::shared_ptr<Tile>& b) {
-                return a->get_diagonal_suqared() > b->get_diagonal_suqared();
-            });
-            break;
-        case PriorityHeuristic::AREA:
-            std::sort(tiles.begin(), tiles.end(), [](const std::shared_ptr<Tile>& a, const std::shared_ptr<Tile>& b) {
-                return a->get_area() > b->get_area();
-            });
-            break;
-        case PriorityHeuristic::ASPECT_RATIO:
-            std::sort(tiles.begin(), tiles.end(), [](const std::shared_ptr<Tile>& a, const std::shared_ptr<Tile>& b) {
-                return a->get_aspect_ratio() > b->get_aspect_ratio();
-            });
-            break;
+    using SortPredicate = bool(*)(const Tile&, const Tile&);
 
-        default:
-            break;
-    }
+    SortPredicate predicate = [&]() -> SortPredicate {
+        switch (heuristic) {
+            case PriorityHeuristic::WIDTH:
+                return [](const Tile& a, const Tile& b) {
+                    return a.get_width() > b.get_width();
+                };
+            case PriorityHeuristic::HEIGHT:
+                return [](const Tile& a, const Tile& b) {
+                    return a.get_height() > b.get_height();
+                };
+            case PriorityHeuristic::DIAGONAL:
+                return [](const Tile& a, const Tile& b) {
+                    return a.get_diagonal_suqared() > b.get_diagonal_suqared();
+                };
+            case PriorityHeuristic::AREA:
+                return [](const Tile& a, const Tile& b) {
+                    return a.get_area() > b.get_area();
+                };
+            case PriorityHeuristic::ASPECT_RATIO:
+                return [](const Tile& a, const Tile& b) {
+                    return a.get_aspect_ratio() > b.get_aspect_ratio();
+                };
+            // We return false to satisfy the strict weak ordering requirement for the predicate.
+            default:
+                return [](const Tile& a, const Tile& b) {
+                    return false;
+                };
+        }
+    }();
+
+    std::sort(tiles.begin(), tiles.end(), predicate);
+    
     return tiles;
 }
 
-cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::shared_ptr<ImageSource>> images) {
+cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) {
     /*
     if (images.empty()) throw std::invalid_argument("No images provided");
     // TODO: checks, check if it fits in any way, etc
@@ -56,7 +59,7 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::sha
     auto document_width = preset.get_document_width_px() + 2 * side_fix;
 
     // apply size and add padding
-    for (auto img : images) {
+    for (const auto& img : images) {
         auto width_px = convert::mm_to_pixel(img->width_mm, ppi);
         auto height_px = convert::mm_to_pixel(img->height_mm, ppi);
         img->set_size_px(width_px, height_px, true);
@@ -66,7 +69,7 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::sha
 
     int min_total_height = std::numeric_limits<int>::max();
     PriorityHeuristic best_heuristic;
-    std::vector<std::shared_ptr<Tile>> best_placement = {};
+    std::vector<Tile> best_placement = {};
 
     
     for (auto heuristic : {
@@ -77,17 +80,23 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::sha
         //PriorityHeuristic::ASPECT_RATIO
     }) {
         // sort by priority heuristic
-        std::vector<std::shared_ptr<Tile>> tiles = {};
-        for (auto img : images) {
-            tiles.push_back(std::make_shared<Tile>(img));
+        std::vector<Tile> tiles;
+        tiles.reserve(images.size());
+
+        for (const auto& img : images) {
+            tiles.emplace_back(Tile(img));
         }
+
         ph_sort(tiles, heuristic);
 
         // instantiate tiles based on amounts
-        std::vector<std::shared_ptr<Tile>> remaining = {};
-        for (auto tile : tiles) {
-            for (int i = 0; i < tile->get_source()->get_amount(); i++) {
-                remaining.push_back(std::make_shared<Tile>(*tile));
+        std::vector<Tile> remaining;
+        // Assuming that on average, each image is printed three times
+        remaining.reserve(images.size() * 3);
+
+        for (const auto& tile : tiles) {
+            for (int i = 0; i < tile.get_source()->get_amount(); i++) {
+                remaining.push_back(tile);
             }
         }
 
@@ -96,20 +105,21 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::sha
         int total_height = 0;
         int row_width = 0, row_height = 0;
 
-        std::vector<std::shared_ptr<Tile>> placed = {};
+        std::vector<Tile> placed;
+        placed.reserve(images.size());
 
         while (!remaining.empty()) {
             auto tile = remaining.front();
             remaining.erase(remaining.begin());
-            int tile_width = tile->get_width();
-            int tile_height = tile->get_height();
+            int tile_width = tile.get_width();
+            int tile_height = tile.get_height();
             
             if (tile_height <= document_width) {
-                tile->rotate();
+                tile.rotate();
                 std::swap(tile_width, tile_height);
             }
             
-            tile->corner = cv::Point(x, y);
+            tile.corner = cv::Point(x, y);
             placed.push_back(tile);
             x = tile_width;
             y = total_height;
@@ -134,17 +144,19 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, std::vector<std::sha
     // place tiles on the document
     auto document_height = min_total_height;
     cv::Mat document(document_height, document_width, CV_8UC3, cv::Scalar(255, 255, 255));
-    for (auto tile : best_placement) {
-        cv::Rect target_rect = cv::Rect(tile->corner.x, tile->corner.y, tile->get_width(), tile->get_height());
 
-        tile->get_image().copyTo(document(target_rect));
+    for (auto& tile : best_placement) {
+        cv::Rect target_rect = cv::Rect(tile.corner.x, tile.corner.y, tile.get_width(), tile.get_height());
+
+        tile.get_image().copyTo(document(target_rect));
     }
+
     document = document(cv::Rect(side_fix, side_fix, document_width - 2 * side_fix, document_height - 2 * side_fix));
 
     return document;
 }
 
-void StripTiling::recursive_packing(int x, int y, int row_width, int row_height, std::vector<std::shared_ptr<Tile>>& remaining, std::vector<std::shared_ptr<Tile>>& placed) {
+void StripTiling::recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining, std::vector<Tile>& placed) {
     int priority = 5;
     int best_idx = -1;
     bool rotate = false;
@@ -152,17 +164,13 @@ void StripTiling::recursive_packing(int x, int y, int row_width, int row_height,
     auto prio = [&](int width, int height, bool is_rotated, int idx) {
         if (priority > 1 && width == row_width && height == row_height) {
             priority = 1;
-        }
-        else if (priority > 2 && width == row_width && height <= row_height) {
+        } else if (priority > 2 && width == row_width && height <= row_height) {
             priority = 2;
-        }
-        else if (priority > 3 && width <= row_width && height == row_height) {
+        } else if (priority > 3 && width <= row_width && height == row_height) {
             priority = 3;
-        }
-        else if (priority > 4 && width <= row_width && height <= row_height) {
+        } else if (priority > 4 && width <= row_width && height <= row_height) {
             priority = 4;
-        }
-        else {
+        } else {
             return;
         }
         best_idx = idx;
@@ -170,9 +178,9 @@ void StripTiling::recursive_packing(int x, int y, int row_width, int row_height,
     };
 
     for (size_t i = 0; i < remaining.size(); i++) {
-        auto tile = remaining[i];
-        int tile_width = tile->get_width();
-        int tile_height = tile->get_height();
+        const auto& tile = remaining[i];
+        int tile_width = tile.get_width();
+        int tile_height = tile.get_height();
 
         prio(tile_width, tile_height, false, i);
         prio(tile_height, tile_width, true, i);
@@ -185,11 +193,13 @@ void StripTiling::recursive_packing(int x, int y, int row_width, int row_height,
     auto tile = remaining[best_idx];
     remaining.erase(remaining.begin() + best_idx);
 
-    if (rotate) tile->rotate();
-    tile->corner = cv::Point(x, y);
+    if (rotate) tile.rotate();
+
+    tile.corner = cv::Point(x, y);
     placed.push_back(tile);
-    auto tile_width = tile->get_width();
-    auto tile_height = tile->get_height();
+
+    auto tile_width = tile.get_width();
+    auto tile_height = tile.get_height();
 
     switch (priority)
     {
@@ -202,7 +212,7 @@ void StripTiling::recursive_packing(int x, int y, int row_width, int row_height,
     case 4:
         int min_side = std::numeric_limits<int>::max();
         for (auto t : remaining) {
-            min_side = std::min({min_side, t->get_width(), t->get_height()});
+            min_side = std::min({min_side, t.get_width(), t.get_height()});
         }
 
         if (row_width - tile_width < min_side) {

--- a/src/img/tiling/strip_tiling.cpp
+++ b/src/img/tiling/strip_tiling.cpp
@@ -10,40 +10,28 @@ std::vector<Tile>& StripTiling::ph_sort(std::vector<Tile>& tiles, PriorityHeuris
         }
     }
 
-    using SortPredicate = bool(*)(const Tile&, const Tile&);
+    using SortPredicate = bool (*)(const Tile&, const Tile&);
 
     SortPredicate predicate = [&]() -> SortPredicate {
         switch (heuristic) {
             case PriorityHeuristic::WIDTH:
-                return [](const Tile& a, const Tile& b) {
-                    return a.get_width() > b.get_width();
-                };
+                return [](const Tile& a, const Tile& b) { return a.get_width() > b.get_width(); };
             case PriorityHeuristic::HEIGHT:
-                return [](const Tile& a, const Tile& b) {
-                    return a.get_height() > b.get_height();
-                };
+                return [](const Tile& a, const Tile& b) { return a.get_height() > b.get_height(); };
             case PriorityHeuristic::DIAGONAL:
-                return [](const Tile& a, const Tile& b) {
-                    return a.get_diagonal_suqared() > b.get_diagonal_suqared();
-                };
+                return [](const Tile& a, const Tile& b) { return a.get_diagonal_suqared() > b.get_diagonal_suqared(); };
             case PriorityHeuristic::AREA:
-                return [](const Tile& a, const Tile& b) {
-                    return a.get_area() > b.get_area();
-                };
+                return [](const Tile& a, const Tile& b) { return a.get_area() > b.get_area(); };
             case PriorityHeuristic::ASPECT_RATIO:
-                return [](const Tile& a, const Tile& b) {
-                    return a.get_aspect_ratio() > b.get_aspect_ratio();
-                };
+                return [](const Tile& a, const Tile& b) { return a.get_aspect_ratio() > b.get_aspect_ratio(); };
             // We return false to satisfy the strict weak ordering requirement for the predicate.
             default:
-                return [](const Tile& a, const Tile& b) {
-                    return false;
-                };
+                return [](const Tile& a, const Tile& b) { return false; };
         }
     }();
 
     std::sort(tiles.begin(), tiles.end(), predicate);
-    
+
     return tiles;
 }
 
@@ -63,7 +51,8 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<Im
         auto width_px = convert::mm_to_pixel(img->width_mm, ppi);
         auto height_px = convert::mm_to_pixel(img->height_mm, ppi);
         img->set_size_px(width_px, height_px, true);
-        img->add_filter(std::make_shared<PaddingFilter>(padding, preset.get_guide(), preset.get_bleed_px(), preset.get_line_width()));
+        img->add_filter(
+            std::make_shared<PaddingFilter>(padding, preset.get_guide(), preset.get_bleed_px(), preset.get_line_width()));
         img->burn();
     }
 
@@ -71,14 +60,13 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<Im
     PriorityHeuristic best_heuristic;
     std::vector<Tile> best_placement = {};
 
-    
     for (auto heuristic : {
-        PriorityHeuristic::WIDTH,
-        PriorityHeuristic::HEIGHT,
-        PriorityHeuristic::DIAGONAL,
-        PriorityHeuristic::AREA,
-        //PriorityHeuristic::ASPECT_RATIO
-    }) {
+             PriorityHeuristic::WIDTH,
+             PriorityHeuristic::HEIGHT,
+             PriorityHeuristic::DIAGONAL,
+             PriorityHeuristic::AREA,
+             // PriorityHeuristic::ASPECT_RATIO
+         }) {
         // sort by priority heuristic
         std::vector<Tile> tiles;
         tiles.reserve(images.size());
@@ -113,12 +101,12 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<Im
             remaining.erase(remaining.begin());
             int tile_width = tile.get_width();
             int tile_height = tile.get_height();
-            
+
             if (tile_height <= document_width) {
                 tile.rotate();
                 std::swap(tile_width, tile_height);
             }
-            
+
             tile.corner = cv::Point(x, y);
             placed.push_back(tile);
             x = tile_width;
@@ -140,7 +128,7 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<Im
         }
     }
     std::cout << "Best heuristic: " << to_string(best_heuristic) << " with height " << min_total_height << std::endl;
-    
+
     // place tiles on the document
     auto document_height = min_total_height;
     cv::Mat document(document_height, document_width, CV_8UC3, cv::Scalar(255, 255, 255));
@@ -156,7 +144,8 @@ cv::Mat StripTiling::generate(const DocumentPreset& preset, const std::vector<Im
     return document;
 }
 
-void StripTiling::recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining, std::vector<Tile>& placed) {
+void StripTiling::recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining,
+                                    std::vector<Tile>& placed) {
     int priority = 5;
     int best_idx = -1;
     bool rotate = false;
@@ -201,35 +190,30 @@ void StripTiling::recursive_packing(int x, int y, int row_width, int row_height,
     auto tile_width = tile.get_width();
     auto tile_height = tile.get_height();
 
-    switch (priority)
-    {
-    case 2:
-        recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
-        break;
-    case 3:
-        recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
-        break;
-    case 4:
-        int min_side = std::numeric_limits<int>::max();
-        for (auto t : remaining) {
-            min_side = std::min({min_side, t.get_width(), t.get_height()});
-        }
+    switch (priority) {
+        case 2:
+            recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
+            break;
+        case 3:
+            recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
+            break;
+        case 4:
+            int min_side = std::numeric_limits<int>::max();
+            for (auto t : remaining) {
+                min_side = std::min({min_side, t.get_width(), t.get_height()});
+            }
 
-        if (row_width - tile_width < min_side) {
-            recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
-        }
-        else if (row_height - tile_height < min_side) {
-            recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
-        }
-        else if (tile_width < min_side) {
-            recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
-            recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
-        }
-        else {
-            recursive_packing(x, y + tile_height, tile_width, row_height - tile_height, remaining, placed);
-            recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
-        }
-        break;
+            if (row_width - tile_width < min_side) {
+                recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
+            } else if (row_height - tile_height < min_side) {
+                recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
+            } else if (tile_width < min_side) {
+                recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
+                recursive_packing(x, y + tile_height, row_width, row_height - tile_height, remaining, placed);
+            } else {
+                recursive_packing(x, y + tile_height, tile_width, row_height - tile_height, remaining, placed);
+                recursive_packing(x + tile_width, y, row_width - tile_width, row_height, remaining, placed);
+            }
+            break;
     }
-
 }

--- a/src/img/tiling/strip_tiling.hpp
+++ b/src/img/tiling/strip_tiling.hpp
@@ -1,24 +1,26 @@
-#include "tiling.hpp"
 #include "tile.hpp"
+#include "tiling.hpp"
 
 enum class PriorityHeuristic { WIDTH, HEIGHT, DIAGONAL, AREA, ASPECT_RATIO };
 
-inline const char* to_string(PriorityHeuristic v)
-{
-    switch (v)
-    {
-        case PriorityHeuristic::WIDTH:     return "WIDTH";
-        case PriorityHeuristic::HEIGHT:    return "HEIGHT";
-        case PriorityHeuristic::DIAGONAL:  return "DIAGONAL";
-        case PriorityHeuristic::AREA:      return "AREA";
+inline const char* to_string(PriorityHeuristic v) {
+    switch (v) {
+            // clang-format off
+        case PriorityHeuristic::WIDTH:        return "WIDTH";
+        case PriorityHeuristic::HEIGHT:       return "HEIGHT";
+        case PriorityHeuristic::DIAGONAL:     return "DIAGONAL";
+        case PriorityHeuristic::AREA:         return "AREA";
         case PriorityHeuristic::ASPECT_RATIO: return "ASPECT_RATIO";
-        default: return "UNKNOWN";
+        default:                              return "UNKNOWN";
+            // clang-format on
     }
 }
 
 class StripTiling : public Tiling {
   private:
-    void recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining, std::vector<Tile>& placed);
+    void recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining,
+                           std::vector<Tile>& placed);
+
   public:
     std::vector<Tile>& ph_sort(std::vector<Tile>& tiles, PriorityHeuristic heuristic = PriorityHeuristic::WIDTH);
     cv::Mat generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) override;

--- a/src/img/tiling/strip_tiling.hpp
+++ b/src/img/tiling/strip_tiling.hpp
@@ -18,8 +18,8 @@ inline const char* to_string(PriorityHeuristic v)
 
 class StripTiling : public Tiling {
   private:
-    void recursive_packing(int x, int y, int row_width, int row_height, std::vector<std::shared_ptr<Tile>>& remaining, std::vector<std::shared_ptr<Tile>>& placed);
+    void recursive_packing(int x, int y, int row_width, int row_height, std::vector<Tile>& remaining, std::vector<Tile>& placed);
   public:
-    std::vector<std::shared_ptr<Tile>>& ph_sort(std::vector<std::shared_ptr<Tile>>& tiles, PriorityHeuristic heuristic = PriorityHeuristic::WIDTH);
-    cv::Mat generate(const DocumentPreset& preset, std::vector<std::shared_ptr<ImageSource>> images) override;
+    std::vector<Tile>& ph_sort(std::vector<Tile>& tiles, PriorityHeuristic heuristic = PriorityHeuristic::WIDTH);
+    cv::Mat generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) override;
 };

--- a/src/img/tiling/tile.hpp
+++ b/src/img/tiling/tile.hpp
@@ -13,11 +13,12 @@ class Tile {
 
     Tile(ImageSource* img) : image(img), width(image->get_width_px()), height(image->get_height_px()) {}
 
-    Tile(const Tile& other) : image(other.image), width(other.width), height(other.height), rotated(other.rotated), corner(other.corner) {}
+    Tile(const Tile& other)
+        : image(other.image), width(other.width), height(other.height), rotated(other.rotated), corner(other.corner) {}
 
-    void rotate() { 
-      std::swap(width, height);
-      rotated = !rotated;
+    void rotate() {
+        std::swap(width, height);
+        rotated = !rotated;
     }
 
     bool is_rotated() const { return rotated; }
@@ -28,13 +29,13 @@ class Tile {
 
     int get_height() const { return height; }
 
-    int get_diagonal_suqared() const { return width * width + height *height; }
+    int get_diagonal_suqared() const { return width * width + height * height; }
 
-    int get_aspect_ratio() const { return (double) width / (double) height; }
+    int get_aspect_ratio() const { return (double)width / (double)height; }
 
     cv::Mat get_image() {
         image->set_rotated(rotated);
-        return image->get_img(); 
+        return image->get_img();
     }
 
     ImageSource* get_source() const { return image; }

--- a/src/img/tiling/tile.hpp
+++ b/src/img/tiling/tile.hpp
@@ -4,19 +4,20 @@
 
 class Tile {
   private:
-    std::shared_ptr<ImageSource> image;
+    ImageSource* image;
     int width, height;
     bool rotated = false;
 
   public:
-    cv::Point corner;
+    cv::Point corner = cv::Point(0, 0);
 
-    Tile(std::shared_ptr<ImageSource> img) : image(img), width(img->get_width_px()), height(img->get_height_px()), corner(cv::Point(0, 0)) {}
+    Tile(ImageSource* img) : image(img), width(image->get_width_px()), height(image->get_height_px()) {}
+
     Tile(const Tile& other) : image(other.image), width(other.width), height(other.height), rotated(other.rotated), corner(other.corner) {}
 
-    void rotate() {
-        std::swap(width, height);
-        rotated = !rotated;
+    void rotate() { 
+      std::swap(width, height);
+      rotated = !rotated;
     }
 
     bool is_rotated() const { return rotated; }
@@ -27,7 +28,7 @@ class Tile {
 
     int get_height() const { return height; }
 
-    int get_diagonal_suqared() const { return width * width + height * height; }
+    int get_diagonal_suqared() const { return width * width + height *height; }
 
     int get_aspect_ratio() const { return (double) width / (double) height; }
 
@@ -36,5 +37,5 @@ class Tile {
         return image->get_img(); 
     }
 
-    std::shared_ptr<ImageSource> get_source() { return image; }
+    ImageSource* get_source() const { return image; }
 };

--- a/src/img/tiling/tiling.hpp
+++ b/src/img/tiling/tiling.hpp
@@ -5,7 +5,7 @@
 
 class Tiling {
   public:
-    virtual cv::Mat generate(const DocumentPreset &preset, std::vector<std::shared_ptr<ImageSource>> images) = 0;
+    virtual cv::Mat generate(const DocumentPreset &preset, const std::vector<ImageSource*>& images) = 0;
     virtual ~Tiling() = default;
 };
 

--- a/src/img/tiling/tiling.hpp
+++ b/src/img/tiling/tiling.hpp
@@ -1,11 +1,11 @@
 #pragma once
+#include <memory>
+
 #include "document_preset.hpp"
 #include "image_source.hpp"
-#include <memory>
 
 class Tiling {
   public:
-    virtual cv::Mat generate(const DocumentPreset &preset, const std::vector<ImageSource*>& images) = 0;
+    virtual cv::Mat generate(const DocumentPreset& preset, const std::vector<ImageSource*>& images) = 0;
     virtual ~Tiling() = default;
 };
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,14 +3,14 @@
 #include <QtQml>
 
 #include "document_properties_view.hpp"
+#include "error_signal.hpp"
 #include "generator_view.hpp"
 #include "mask_filter_view.hpp"
 #include "preset_view.hpp"
 #include "preview_provider.hpp"
 #include "source_entry_view.hpp"
-#include "error_signal.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
 
     qmlRegisterType<SourceEntryView>("printf", 1, 0, "SourceEntryView");
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<DocumentPropertiesView>("printf", 1, 0, "DocumentPropertiesView");
     qmlRegisterType<GeneratorView>("printf", 1, 0, "GeneratorView");
     qmlRegisterType<ErrorSignal>("printf", 1, 0, "ErrorSignal");
-    
+
     qRegisterMetaType<MaskFilterView>("MaskFilterView");
     qRegisterMetaType<ImageSourceView>("ImageSourceView");
     qRegisterMetaType<DocumentPreset>("DocumentPreset");

--- a/src/settings/document_preset.hpp
+++ b/src/settings/document_preset.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <string>
+
 #include "convert.hpp"
 
 class DocumentPreset {
@@ -22,8 +23,8 @@ class DocumentPreset {
     DocumentPreset(
         // FIXME
         double ppi = 300, double roll_width_mm = 914.4, double margin_mm = 0, double gutter_mm = 2,
-        bool correct_quantity = false, bool guide = true, int line_width_px = 10, double bleed_mm = 10, double min_height_mm = 101.6,
-        double max_height_mm = 18000);
+        bool correct_quantity = false, bool guide = true, int line_width_px = 10, double bleed_mm = 10,
+        double min_height_mm = 101.6, double max_height_mm = 18000);
 
     double get_ppi() const { return ppi; }
 

--- a/src/ui/document_properties_view.cpp
+++ b/src/ui/document_properties_view.cpp
@@ -10,7 +10,16 @@ using json = nlohmann::json;
 
 // TODO: remove constants
 DocumentPropertiesView::DocumentPropertiesView()
-    : m_resolution(300), m_roll_width(914.4), m_margin(0), m_correct_quantity(false), m_gutter(2), m_guides(true), m_line_width(1), m_bleed(10), m_min_height(101.6), m_max_height(18000) {}
+    : m_resolution(300),
+      m_roll_width(914.4),
+      m_margin(0),
+      m_correct_quantity(false),
+      m_gutter(2),
+      m_guides(true),
+      m_line_width(1),
+      m_bleed(10),
+      m_min_height(101.6),
+      m_max_height(18000) {}
 
 void DocumentPropertiesView::load_from_preset(const std::string& preset_path, const std::string& subcategory) {
     std::cout << "Loading preset from: " << preset_path << std::endl;
@@ -28,10 +37,9 @@ void DocumentPropertiesView::load_from_preset(const std::string& preset_path, co
     f.close();
 
     if (!subcategory.empty()) {
-        if (j.contains(subcategory)){
+        if (j.contains(subcategory)) {
             j = j[subcategory];
-        }
-        else {
+        } else {
             return;
         }
     }
@@ -79,8 +87,11 @@ void DocumentPropertiesView::load_from_preset(const std::string& preset_path, co
     }
 }
 
-void DocumentPropertiesView::setPreset(const QString& presetPath, const QString& subcategory) { load_from_preset(presetPath.toStdString(), subcategory.toStdString()); }
+void DocumentPropertiesView::setPreset(const QString& presetPath, const QString& subcategory) {
+    load_from_preset(presetPath.toStdString(), subcategory.toStdString());
+}
 
 DocumentPreset DocumentPropertiesView::getDocumentProperties() const {
-    return DocumentPreset(m_resolution, m_roll_width, m_margin, m_gutter, m_correct_quantity, m_guides, m_line_width, m_bleed, m_min_height, m_max_height);
+    return DocumentPreset(m_resolution, m_roll_width, m_margin, m_gutter, m_correct_quantity, m_guides, m_line_width, m_bleed,
+                          m_min_height, m_max_height);
 }

--- a/src/ui/document_properties_view.hpp
+++ b/src/ui/document_properties_view.hpp
@@ -2,8 +2,8 @@
 
 #include <QtCore>
 #include <QtGui>
-#include <string>
 #include <document_preset.hpp>
+#include <string>
 
 class DocumentPropertiesView : public QObject {
     Q_OBJECT

--- a/src/ui/error_signal.hpp
+++ b/src/ui/error_signal.hpp
@@ -3,33 +3,22 @@
 
 class ErrorSignal : public QObject {
     Q_OBJECT
-private:
+  private:
     static ErrorSignal* m_instance;
 
-public:
-    static ErrorSignal* instance() {
-        return m_instance;
-    }
+  public:
+    static ErrorSignal* instance() { return m_instance; }
 
     ErrorSignal();
 
-    Q_INVOKABLE void error(const QString& error) {
-        emit instance()->onError(error);
-    }
+    Q_INVOKABLE void error(const QString& error) { emit instance() -> onError(error); }
 
-    Q_INVOKABLE void info(const QString& info) {
-        emit instance()->onInfo(info);
-    }
+    Q_INVOKABLE void info(const QString& info) { emit instance() -> onInfo(info); }
 
-    static void ierror(const QString& error) {
-        instance()->error(error);
-    }
-    static void iinfo(const QString& info) {
-        instance()->info(info);
-    }
+    static void ierror(const QString& error) { instance()->error(error); }
+    static void iinfo(const QString& info) { instance()->info(info); }
 
-signals:
+  signals:
     void onError(QString error);
     void onInfo(QString info);
 };
-

--- a/src/ui/generator_view.cpp
+++ b/src/ui/generator_view.cpp
@@ -5,12 +5,12 @@
 #include <exiv2/exiv2.hpp>
 #include <iostream>
 
-#include "grid_tiling.hpp"
-#include "strip_tiling.hpp"
-#include "preview_provider.hpp"
-#include "pnghelper.hpp"
-#include "error_signal.hpp"
 #include "convert.hpp"
+#include "error_signal.hpp"
+#include "grid_tiling.hpp"
+#include "pnghelper.hpp"
+#include "preview_provider.hpp"
+#include "strip_tiling.hpp"
 
 GeneratorView::GeneratorView() {}
 
@@ -29,7 +29,7 @@ void GeneratorView::generate(const DocumentPreset& properties, const QList<std::
     for (const auto& src : sources) {
         raw_sources.push_back(src.get());
     }
-        
+
     Tiling* tiling;
     if (raw_sources.size() == 1) {
         tiling = new GridTiling();
@@ -37,8 +37,7 @@ void GeneratorView::generate(const DocumentPreset& properties, const QList<std::
         tiling = new StripTiling();
     }
 
-
-    cv::Mat result = tiling->generate(properties, raw_sources); 
+    cv::Mat result = tiling->generate(properties, raw_sources);
 
     delete tiling;
 
@@ -48,10 +47,10 @@ void GeneratorView::generate(const DocumentPreset& properties, const QList<std::
 
     QImage image(result.data, result.cols, result.rows, result.step, QImage::Format_BGR888);
     PreviewProvider::instance()->setImage(image.copy());
-
 }
 
-QFuture<void> GeneratorView::asyncGenerate(const DocumentPreset& properties, const QList<std::shared_ptr<ImageSource>>& sources) {
+QFuture<void> GeneratorView::asyncGenerate(const DocumentPreset& properties,
+                                           const QList<std::shared_ptr<ImageSource>>& sources) {
     return QtConcurrent::run([=, this]() {
         ErrorSignal::iinfo("Generating image...");
         try {
@@ -60,14 +59,18 @@ QFuture<void> GeneratorView::asyncGenerate(const DocumentPreset& properties, con
             const auto width = img.width();
             const auto height = img.height();
             const auto ppi = properties.get_ppi();
-                
+
             // TODO: handle properly
-            if (height > properties.get_max_height_px()) 
+            if (height > properties.get_max_height_px())
                 ErrorSignal::ierror("Generated image exceeds maximum height");
-            else if (height < properties.get_min_height_px()) 
+            else if (height < properties.get_min_height_px())
                 ErrorSignal::ierror("Generated image is below minimum height");
-            else 
-                ErrorSignal::iinfo(QString("%1 x %2 px - %3 x %4 mm").arg(width).arg(height).arg(convert::pixel_to_mm(width, ppi)).arg(convert::pixel_to_mm(height, ppi)));
+            else
+                ErrorSignal::iinfo(QString("%1 x %2 px - %3 x %4 mm")
+                                       .arg(width)
+                                       .arg(height)
+                                       .arg(convert::pixel_to_mm(width, ppi))
+                                       .arg(convert::pixel_to_mm(height, ppi)));
         } catch (const std::exception& e) {
             std::cerr << e.what() << std::endl;
             PreviewProvider::instance()->setImage(QImage());
@@ -87,7 +90,7 @@ void GeneratorView::save(const QString& path, const DocumentPreset& properties) 
     if (out_path.rfind("file://", 0) == 0) {
         out_path = out_path.substr(7);
     }
-    
+
     // TODO: save as jpeg
     PNGHelper::save_png(out_path, image, properties.get_ppi());
     PNGHelper::add_exif_data(out_path, properties);

--- a/src/ui/generator_view.cpp
+++ b/src/ui/generator_view.cpp
@@ -1,6 +1,7 @@
 #include "generator_view.hpp"
 
 #include <QtConcurrent/QtConcurrent>
+#include <chrono>
 #include <exiv2/exiv2.hpp>
 #include <iostream>
 
@@ -14,19 +15,31 @@
 GeneratorView::GeneratorView() {}
 
 void GeneratorView::generate(const DocumentPreset& properties, const QList<std::shared_ptr<ImageSource>>& sources) {
-    std::vector<std::shared_ptr<ImageSource>> sources_vector(sources.constBegin(), sources.constEnd());
-    
-    if (sources_vector.empty()) {
+    if (sources.empty()) {
         throw std::invalid_argument("No image sources provided");
     }
-    
+
+    // TODO: Instead of passing around std::shared_ptr's in QML,
+    // we should move to only passing around handles, like Cache IDs.
+    // For now, lets just extract the raw pointers from QML to use for
+    // our tiling algorithms.
+    std::vector<ImageSource*> raw_sources;
+    raw_sources.reserve(sources.size());
+
+    for (const auto& src : sources) {
+        raw_sources.push_back(src.get());
+    }
+        
     Tiling* tiling;
-    if (sources_vector.size() == 1) {
+    if (raw_sources.size() == 1) {
         tiling = new GridTiling();
     } else {
         tiling = new StripTiling();
     }
-    cv::Mat result = tiling->generate(properties, sources_vector);
+
+
+    cv::Mat result = tiling->generate(properties, raw_sources); 
+
     delete tiling;
 
     if (result.empty()) {

--- a/src/ui/generator_view.hpp
+++ b/src/ui/generator_view.hpp
@@ -11,7 +11,8 @@ class GeneratorView : public QObject {
     GeneratorView();
 
     void generate(const DocumentPreset& properties, const QList<std::shared_ptr<ImageSource>>& sources);
-    Q_INVOKABLE QFuture<void> asyncGenerate(const DocumentPreset& properties, const QList<std::shared_ptr<ImageSource>>& sources);
+    Q_INVOKABLE QFuture<void> asyncGenerate(const DocumentPreset& properties,
+                                            const QList<std::shared_ptr<ImageSource>>& sources);
 
     void save(const QString& path, const DocumentPreset& properties);
     Q_INVOKABLE QFuture<void> asyncSave(const QString& path, const DocumentPreset& properties);

--- a/src/ui/ifilter_view.hpp
+++ b/src/ui/ifilter_view.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <QtCore>
-#include "ifilter.hpp"
 #include <memory>
 
+#include "ifilter.hpp"
+
 class IFilterView : public QObject {
-  Q_OBJECT
+    Q_OBJECT
   public:
-    virtual std::shared_ptr<IFilter> get_filter() const = 0; // TODO: shared pointer
+    virtual std::shared_ptr<IFilter> get_filter() const = 0;  // TODO: shared pointer
     virtual bool is_enabled() const = 0;
 };

--- a/src/ui/image_source_view.cpp
+++ b/src/ui/image_source_view.cpp
@@ -9,15 +9,15 @@
 #include "nlohmann/json.hpp"
 using json = nlohmann::json;
 
-ImageSourceView::ImageSourceView(): m_file_path(""), m_image(cv::Mat()), m_amount(1), m_width(0), m_height(0), mask_filter_view() {}
+ImageSourceView::ImageSourceView()
+    : m_file_path(""), m_image(cv::Mat()), m_amount(1), m_width(0), m_height(0), mask_filter_view() {}
 
 void ImageSourceView::load(const std::string& path, int amount, double ppi) {
     m_amount = amount;
-    
+
     if (path.rfind("file://", 0) == 0) {
         m_file_path = path.substr(7);
-    }
-    else {
+    } else {
         m_file_path = path;
     }
 
@@ -31,7 +31,7 @@ void ImageSourceView::load_image(double ppi) {
     if (!std::filesystem::exists(m_file_path)) {
         throw std::invalid_argument("File does not exist: " + m_file_path);
     }
-    
+
     m_image = cv::imread(m_file_path, cv::IMREAD_UNCHANGED);
     if (m_image.empty()) {
         throw std::runtime_error("Failed to load image: " + m_file_path);
@@ -119,7 +119,7 @@ void ImageSourceView::load_from_preset(const std::string& preset_path) {
     }
 }
 
-std::shared_ptr<ImageSource> ImageSourceView::get_image_source(const DocumentPreset &preset) {
+std::shared_ptr<ImageSource> ImageSourceView::get_image_source(const DocumentPreset& preset) {
     auto img = std::make_shared<ImageSource>(m_image, m_amount, m_width, m_height);
     if (mask_filter_view.is_enabled()) img->add_filter(mask_filter_view.get_filter());
     return img;

--- a/src/ui/image_source_view.hpp
+++ b/src/ui/image_source_view.hpp
@@ -6,10 +6,10 @@
 #include <string>
 #include <vector>
 
-#include "image_source.hpp"
-#include "ifilter_view.hpp"
-#include "mask_filter_view.hpp"
 #include "document_preset.hpp"
+#include "ifilter_view.hpp"
+#include "image_source.hpp"
+#include "mask_filter_view.hpp"
 
 class ImageSourceView : public QObject {
     Q_OBJECT
@@ -53,7 +53,7 @@ class ImageSourceView : public QObject {
 
     void load_from_preset(const std::string& preset_path);
 
-    virtual std::shared_ptr<ImageSource> get_image_source(const DocumentPreset &preset);
+    virtual std::shared_ptr<ImageSource> get_image_source(const DocumentPreset& preset);
 
     MaskFilterView* get_mask_filter_view();
 

--- a/src/ui/mask_filter_view.hpp
+++ b/src/ui/mask_filter_view.hpp
@@ -2,9 +2,10 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <memory>
 #include <opencv2/opencv.hpp>
 #include <string>
-#include <memory>
+
 #include "ifilter_view.hpp"
 
 class MaskFilterView : public IFilterView {

--- a/src/ui/pdf_source_view.cpp
+++ b/src/ui/pdf_source_view.cpp
@@ -1,5 +1,7 @@
 #include "pdf_source_view.hpp"
+
 #include <poppler-qt6.h>
+
 #include <iostream>
 
 PDFSourceView::PDFSourceView() : ImageSourceView() {}
@@ -11,12 +13,11 @@ std::shared_ptr<ImageSource> PDFSourceView::get_image_source(const DocumentPrese
 }
 
 void PDFSourceView::load_image(double ppi) {
-
     auto doc = Poppler::Document::load(QString::fromStdString(m_file_path));
     if (!doc) {
         throw std::runtime_error("Failed to load pdf: " + m_file_path);
     }
-    
+
     auto page = doc->page(0);
     if (!page) {
         throw std::runtime_error("Failed to the first page of the pdf: " + m_file_path);

--- a/src/ui/pdf_source_view.hpp
+++ b/src/ui/pdf_source_view.hpp
@@ -12,5 +12,5 @@ class PDFSourceView : public ImageSourceView {
   public:
     PDFSourceView();
 
-    virtual std::shared_ptr<ImageSource> get_image_source(const DocumentPreset &preset) override;
+    virtual std::shared_ptr<ImageSource> get_image_source(const DocumentPreset& preset) override;
 };

--- a/src/ui/preset_view.cpp
+++ b/src/ui/preset_view.cpp
@@ -1,6 +1,6 @@
 #include "preset_view.hpp"
 
-PresetView::PresetView(QObject *parent) : QAbstractListModel(parent) {
+PresetView::PresetView(QObject* parent) : QAbstractListModel(parent) {
     m_path = QString();
 
     m_roleNames[NameRole] = "name";
@@ -20,19 +20,19 @@ void PresetView::fetch_entries() {
     m_data.append(std::make_pair("None", ""));
 
     auto presets = jsonprobe::probe_presets(m_path.toStdString(), "name");
-    for (const auto &preset : *presets) {
+    for (const auto& preset : *presets) {
         m_data.append(preset);
     }
 
     endResetModel();
 }
 
-int PresetView::rowCount(const QModelIndex &parent) const {
+int PresetView::rowCount(const QModelIndex& parent) const {
     Q_UNUSED(parent);
     return m_data.count();
 }
 
-QVariant PresetView::data(const QModelIndex &index, int role) const {
+QVariant PresetView::data(const QModelIndex& index, int role) const {
     int row = index.row();
 
     // oob check
@@ -54,7 +54,7 @@ QVariant PresetView::data(const QModelIndex &index, int role) const {
 
 QString PresetView::get_path() const { return m_path; }
 
-void PresetView::set_path(const QString &path) {
+void PresetView::set_path(const QString& path) {
     if (m_path != path) {
         m_path = path;
 

--- a/src/ui/preset_view.hpp
+++ b/src/ui/preset_view.hpp
@@ -15,7 +15,7 @@ class PresetView : public QAbstractListModel {
         PathRole = Qt::UserRole + 1,
     };
 
-    explicit PresetView(QObject *parent = 0);
+    explicit PresetView(QObject* parent = 0);
     ~PresetView();
 
   protected:
@@ -29,11 +29,11 @@ class PresetView : public QAbstractListModel {
     void fetch_entries();
 
   public:
-    virtual int rowCount(const QModelIndex &parent) const;
-    virtual QVariant data(const QModelIndex &index, int role) const;
+    virtual int rowCount(const QModelIndex& parent) const;
+    virtual QVariant data(const QModelIndex& index, int role) const;
 
     QString get_path() const;
-    void set_path(const QString &path);
+    void set_path(const QString& path);
 
     Q_INVOKABLE QString getPath(int index);
 

--- a/src/ui/source_entry_view.cpp
+++ b/src/ui/source_entry_view.cpp
@@ -1,7 +1,8 @@
 #include "source_entry_view.hpp"
+
 #include "pdf_source_view.hpp"
 
-SourceEntryView::SourceEntryView(QObject *parent) : QAbstractListModel(parent) { m_data = QList<ImageSourceView *>(); }
+SourceEntryView::SourceEntryView(QObject* parent) : QAbstractListModel(parent) { m_data = QList<ImageSourceView*>(); }
 
 SourceEntryView::~SourceEntryView() {
     qDeleteAll(m_data);
@@ -10,12 +11,12 @@ SourceEntryView::~SourceEntryView() {
 
 QHash<int, QByteArray> SourceEntryView::roleNames() const { return {{Qt::UserRole, "entry"}}; }
 
-int SourceEntryView::rowCount(const QModelIndex &parent) const {
+int SourceEntryView::rowCount(const QModelIndex& parent) const {
     Q_UNUSED(parent);
     return m_data.count();
 }
 
-QVariant SourceEntryView::data(const QModelIndex &index, int role) const {
+QVariant SourceEntryView::data(const QModelIndex& index, int role) const {
     // oob check
     if (!index.isValid() || index.row() >= m_data.size()) return QVariant();
 
@@ -46,18 +47,17 @@ void SourceEntryView::clear() {
     emit amountChanged();
 }
 
-void SourceEntryView::addFiles(const QStringList &files) {
-    for (const QString &file : files) {
-        ImageSourceView *input_file;
+void SourceEntryView::addFiles(const QStringList& files) {
+    for (const QString& file : files) {
+        ImageSourceView* input_file;
         if (file.endsWith(".pdf", Qt::CaseInsensitive)) {
             input_file = new PDFSourceView();
-            input_file->load(file.toStdString()); // TODO configurable default amount
-        }
-        else {
+            input_file->load(file.toStdString());  // TODO configurable default amount
+        } else {
             input_file = new ImageSourceView();
             input_file->load(file.toStdString());
         }
-        
+
         beginInsertRows(QModelIndex(), m_data.count(), m_data.count());
         m_data.append(input_file);
         endInsertRows();
@@ -65,9 +65,9 @@ void SourceEntryView::addFiles(const QStringList &files) {
     emit amountChanged();
 }
 
-QList<std::shared_ptr<ImageSource>> SourceEntryView::getImageSources(const DocumentPreset &preset) {
+QList<std::shared_ptr<ImageSource>> SourceEntryView::getImageSources(const DocumentPreset& preset) {
     QList<std::shared_ptr<ImageSource>> sources;
-    for (auto &source : m_data) {
+    for (auto& source : m_data) {
         sources.append(source->get_image_source(preset));
     }
     return sources;

--- a/src/ui/source_entry_view.hpp
+++ b/src/ui/source_entry_view.hpp
@@ -4,16 +4,16 @@
 #include <QtGui>
 #include <memory>
 
-#include "image_source_view.hpp"
-#include "image_source.hpp"
 #include "document_preset.hpp"
+#include "image_source.hpp"
+#include "image_source_view.hpp"
 
 class SourceEntryView : public QAbstractListModel {
     Q_OBJECT
     Q_PROPERTY(int count READ get_count NOTIFY amountChanged)
-    
+
   public:
-    explicit SourceEntryView(QObject *parent = 0);
+    explicit SourceEntryView(QObject* parent = 0);
     ~SourceEntryView();
 
   protected:
@@ -22,19 +22,19 @@ class SourceEntryView : public QAbstractListModel {
   private:
     // TODO: shared pointer
     // so that deleting while its generating wont result in bugs
-    QList<ImageSourceView *> m_data;
+    QList<ImageSourceView*> m_data;
 
   public:
-    virtual int rowCount(const QModelIndex &parent) const override;
-    virtual QVariant data(const QModelIndex &index, int role) const override;
+    virtual int rowCount(const QModelIndex& parent) const override;
+    virtual QVariant data(const QModelIndex& index, int role) const override;
 
     int get_count() const;
 
     Q_INVOKABLE void remove(int index);
     Q_INVOKABLE void clear();
-    Q_INVOKABLE void addFiles(const QStringList &files);
+    Q_INVOKABLE void addFiles(const QStringList& files);
 
-    Q_INVOKABLE QList<std::shared_ptr<ImageSource>> getImageSources(const DocumentPreset &preset);
+    Q_INVOKABLE QList<std::shared_ptr<ImageSource>> getImageSources(const DocumentPreset& preset);
 
   signals:
     void amountChanged();

--- a/src/util/convert.hpp
+++ b/src/util/convert.hpp
@@ -10,4 +10,4 @@ namespace convert {
 
     inline double ppi_to_ppm(double inch) { return inch / 0.0254; }
 
-}  // namespace Convert
+}  // namespace convert

--- a/src/util/defaults.hpp
+++ b/src/util/defaults.hpp
@@ -1,7 +1,4 @@
 #pragma once
 
 // TODO
-namespace defaults
-{
-
-} // namespace defaults
+namespace defaults {}  // namespace defaults

--- a/src/util/jsonprobe.hpp
+++ b/src/util/jsonprobe.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 typedef std::vector<std::pair<std::string, std::string>> ProbeList;
 
-namespace jsonprobe
-{
-    std::unique_ptr<ProbeList> probe_presets(const std::string& preset_dir_path, const std::string& display, const std::string& extension = ".json");
+namespace jsonprobe {
+    std::unique_ptr<ProbeList> probe_presets(const std::string& preset_dir_path, const std::string& display,
+                                             const std::string& extension = ".json");
 }

--- a/src/util/pnghelper.cpp
+++ b/src/util/pnghelper.cpp
@@ -1,6 +1,7 @@
 #include "pnghelper.hpp"
 
 #include <stdexcept>
+
 #include "convert.hpp"
 #include "spng.h"
 


### PR DESCRIPTION
This is part one in a series of PRs to try and improve the performance of printf. In this first PR, I refactored the tiling algorithms to use raw pointers instead of `std::shared_ptr`. This PR is best reviewed commit-by-commit.

## Motivation

The `std::shared_ptr` smart pointer is for shared ownership. It is a reference counted pointer, which comes with overhead. However, the tiling algorithms don't really need ownership of the underlying image data at all to sort them: they just need some general information, like width, height, etc.

## Main changes

Currently on `main`, `Tile` is defined as:
```cpp
class Tile {
  private:
    // Note the ownership of the underlying image source
    std::shared_ptr<ImageSource> image;
    int width, height;
    bool rotated = false;

  public:
    // other fields and methods
}
```
This PR changes `Tile` to use a raw pointer instead:
```cpp
class Tile {
  private:
    ImageSource* image;
    int width, height;
    bool rotated = false;

  public:
    // other fields and methods
}
```
and also changes most of the tiling functions to use vectors of these raw pointers instead of `std::shared_ptr`. I also use `std::vector::reserve` when initializing new vectors instead of doing `= {};`. Some other minor code changes are also present, but shouldn't mess with the logic of the program.

## Crude benchmarks

Obviously take this with a huge grain of salt, since I used pretty hacky methods, but I think the results are still worth sharing.

### Methodology

1. Run `meson configure build -Dbuildtype=debugoptimized` followed by `ninja -C build`
2. Run `/usr/bin/time -v ./build/printf`
3. Once the app starts, load in the seven placeholder assets (`_1.png` through `_7.png`)
4. Set each of them to 1000 instances
5. Hit generate
6. As soon as the preview loads, quit the app
7. (Repeat the whole procedure a couple more times)

### Results

Overall, this PR achieves around a ~20% speedup in user time, while not changing the amount of memory used by the program. Obviously this is for 7k images, so for less images the speedup might be a bit more gradual.

<details>

<summary>How to read outputs</summary>

- User time is the amount of time the CPU spent doing compute-heavy work. For `main`, it's 4.57 seconds, for `speedster`, it's 3.70 seconds.
- Maximum resident set size is the maximum amount of RAM the application used at one point in time. For both branches, this is roughly 8 GBs of RAM (for seven thousand images, this seems expected).

</details>

<details>

<summary>Output for `main` branch</summary>

```
main ?1 λ❯ /usr/bin/time -v ./build/printf
Best heuristic: WIDTH with height 61033
        Command being timed: "./build/printf"
        User time (seconds): 4.57
        System time (seconds): 2.09
        Percent of CPU this job got: 34%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:19.28
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 7688140
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 290534
        Voluntary context switches: 50707
        Involuntary context switches: 1987
        Swaps: 0
        File system inputs: 8
        File system outputs: 1272
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0 
```

</details>

<details>

<summary>Output for `speedster` branch</summary>

```
speedster λ❯ /usr/bin/time -v ./build/printf
Best heuristic: WIDTH with height 61047
        Command being timed: "./build/printf"
        User time (seconds): 3.70
        System time (seconds): 2.39
        Percent of CPU this job got: 24%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:24.58
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 7688360
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 307849
        Voluntary context switches: 60110
        Involuntary context switches: 1381
        Swaps: 0
        File system inputs: 144
        File system outputs: 1272
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0 
```

</details>

## Future improvements

In the following sets of PRs, I plan to implement a cache system so that no `std::shared_ptr`s are ever passed around, not even in QML. Using an arena allocator, one could simply pass the keys around instead of `std::shared_ptr<ImageSource>` or `ImageSource*`, and index into the arena whenever needed.